### PR TITLE
Update lib.coffee

### DIFF
--- a/lib.coffee
+++ b/lib.coffee
@@ -1,4 +1,4 @@
-done = (user, done) -> done null, user
+done = (user, req, done) -> done null, user
 passportStub = (req, res, next) =>
   return next() unless @active
   passport =


### PR DESCRIPTION
So this is to adapt the code to the newest version of passport. The contract for the `done()` function has changed:
stub: before change:

```
done = (user, done) ->
   ... ... 
```

stub: after fix:

```
done = (user, req, done) ->
   ... ...
```

see: line 410

ref: [passport commit](https://github.com/jaredhanson/passport/commit/436e476ddcce74a590413899f43755959a6bccc1#diff-c43b0c8314154da04a21752407f055f3R410)

problem is solved by adding a req parameter to the function. 

However, in the commit mentioned above, it does look like the author made it backward compatible, yet it does not work for us. Is this because we are injecting passport-stub after passport has been initialized?
