### PR TITLE
Fix coffee-script require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require('coffee-script');
+require('coffee-script/register');
 module.exports = require('./lib');


### PR DESCRIPTION
From CoffeeScript changelog:

```
1.7.0 – JANUARY 28, 2014
When requiring CoffeeScript files in Node you must now explicitly register the compiler. This can be done with require 'coffee-script/register' or CoffeeScript.register(). Also for configuration such as Mocha's, use coffee-script/register.
```
