### PR TITLE
Add handle_request property for Express 4.6 compatibility

### DIFF
--- a/lib.coffee
+++ b/lib.coffee
@@ -16,6 +16,7 @@ exports.install = (@app) -> @app._router.stack.unshift
   match: -> yes
   path: ''
   handle: passportStub
+  handle_request: passportStub
   _id: 'passport.stub'
 
 exports.uninstall = ->


### PR DESCRIPTION
As of Express 4.6, the Layer object that gets inserted into the front
of the app's middleware stack in `passportStub.install()` needs a callable
handle_request method. Running passportStub.install() in Express 4.6 or later will throw
the error `Uncaught TypeError: Object #<Object> has no method 'handle_request'`
See https://github.com/visionmedia/express/blob/4.6.0/lib/router/layer.js, line 67
