### PR TITLE
Adds setter for user on request.

### DIFF
--- a/lib.coffee
+++ b/lib.coffee
@@ -10,6 +10,7 @@ passportStub = (req, res, next) =>
     instance: passport
     session : user: @user
   req.__defineGetter__ 'user', => @user
+  req.__defineSetter__ 'user', (val) => @user = val
   next()
 
 exports.install = (@app) -> @app._router.stack.unshift


### PR DESCRIPTION
Was having trouble using passport-stub in conjunction with [connect-roles](https://github.com/ForbesLindesay/connect-roles). Adding a setter for the user property fixes this.