### PR TITLE
Adding .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules/
+src/


### PR DESCRIPTION
It's amazing what you can learn by reading [the docs](https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package):

> If there's no .npmignore file, but there is a .gitignore file, then npm will ignore the stuff matched by the .gitignore file.

Because I was excluding the compiled `'lib/` folder from git, npm *helpfully* ignored it too. 