### PR TITLE
add use function

### DIFF
--- a/src/passport-stub.coffee
+++ b/src/passport-stub.coffee
@@ -13,6 +13,8 @@ passportStub = (req, res, next) =>
   req.__defineSetter__ 'user', (val) => @user = val
   next()
 
+exports.use = (@app) -> @app.use(passportStub)
+
 exports.install = (@app) -> @app._router.stack.unshift
   match: -> yes
   path: ''


### PR DESCRIPTION
`use` function is intended for a better personalized use. It should be something like this:

Config express file
```javascript
...
app.use(passport.initialze());
app.use(passport.session());
if(process.env.NODE_ENV === 'test'){
  require('passport-stub').use(app);
}
```